### PR TITLE
Let iOS use correct random function

### DIFF
--- a/Sources/Atem/Connection.swift
+++ b/Sources/Atem/Connection.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if os(macOS)
+#if os(macOS) || os(iOS)
 let random = arc4random
 #endif
 


### PR DESCRIPTION
Resolves this build error for an iOS project:

`'random()' is unavailable in Swift: Use arc4random instead.`