### PR TITLE
Keyers and Macros

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "120acb15c39aa3217e9888e515de160378fbcc1e",
-          "version": "2.18.0"
+          "revision": "43931b7a7daf8120a487601530c8bc03ce711992",
+          "version": "2.25.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "7cd24c0efcf9700033f671b6a8eaa64a77dd0b72",
-          "version": "1.5.1"
+          "revision": "e5b5d191a80667a14827bfeb0ae4a511f7677942",
+          "version": "1.7.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
 		.executable(name: "DSK", targets: ["DSK"]),
 		.executable(name: "USK", targets: ["USK"]),
 		.executable(name: "Macro", targets: ["Macro"]),
-		.executable(name: "ProductInfo", targets: ["ProductInfo"])
+		.executable(name: "ProductName", targets: ["ProductName"])
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -40,7 +40,7 @@ let package = Package(
 		.target(name: "DSK", dependencies: ["Atem"]),
 		.target(name: "USK", dependencies: ["Atem"]),
 		.target(name: "Macro", dependencies: ["Atem"]),
-		.target(name: "ProductInfo", dependencies: ["Atem"]),
+		.target(name: "ProductName", dependencies: ["Atem"]),
         .testTarget(
             name: "AtemTests",
             dependencies: ["Atem"]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,9 @@ let package = Package(
 		.executable(name: "TitleGenerator", targets: ["TitleGenerator"]),
 		.executable(name: "PreviewSwitcher", targets: ["PreviewSwitcher"]),
 		.executable(name: "SourceLabeler", targets: ["SourceLabeler"]),
-		.executable(name: "MessageDecoder", targets: ["MessageDecoder"])
+		.executable(name: "MessageDecoder", targets: ["MessageDecoder"]),
+		.executable(name: "DSK", targets: ["DSK"]),
+		.executable(name: "USK", targets: ["USK"])
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -33,6 +35,8 @@ let package = Package(
 		.target(name: "PreviewSwitcher", dependencies: ["Atem"]),
 		.target(name: "SourceLabeler", dependencies: ["Atem"]),
 		.target(name: "MessageDecoder", dependencies: ["Atem"]),
+		.target(name: "DSK", dependencies: ["Atem"]),
+		.target(name: "USK", dependencies: ["Atem"]),
         .testTarget(
             name: "AtemTests",
             dependencies: ["Atem"]

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
 		.executable(name: "MessageDecoder", targets: ["MessageDecoder"]),
 		.executable(name: "DSK", targets: ["DSK"]),
 		.executable(name: "USK", targets: ["USK"]),
-		.executable(name: "Macro", targets: ["Macro"])
+		.executable(name: "Macro", targets: ["Macro"]),
+		.executable(name: "ProductInfo", targets: ["ProductInfo"])
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -39,6 +40,7 @@ let package = Package(
 		.target(name: "DSK", dependencies: ["Atem"]),
 		.target(name: "USK", dependencies: ["Atem"]),
 		.target(name: "Macro", dependencies: ["Atem"]),
+		.target(name: "ProductInfo", dependencies: ["Atem"]),
         .testTarget(
             name: "AtemTests",
             dependencies: ["Atem"]

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,8 @@ let package = Package(
 		.executable(name: "SourceLabeler", targets: ["SourceLabeler"]),
 		.executable(name: "MessageDecoder", targets: ["MessageDecoder"]),
 		.executable(name: "DSK", targets: ["DSK"]),
-		.executable(name: "USK", targets: ["USK"])
+		.executable(name: "USK", targets: ["USK"]),
+		.executable(name: "Macro", targets: ["Macro"])
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -37,6 +38,7 @@ let package = Package(
 		.target(name: "MessageDecoder", dependencies: ["Atem"]),
 		.target(name: "DSK", dependencies: ["Atem"]),
 		.target(name: "USK", dependencies: ["Atem"]),
+		.target(name: "Macro", dependencies: ["Atem"]),
         .testTarget(
             name: "AtemTests",
             dependencies: ["Atem"]

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
 		.executable(name: "SourceLabeler", targets: ["SourceLabeler"]),
 		.executable(name: "MessageDecoder", targets: ["MessageDecoder"]),
 		.executable(name: "DSK", targets: ["DSK"]),
+		.executable(name: "DSKSource", targets: ["DSKSource"]),
 		.executable(name: "USK", targets: ["USK"]),
 		.executable(name: "Macro", targets: ["Macro"]),
 		.executable(name: "ProductName", targets: ["ProductName"])
@@ -38,6 +39,7 @@ let package = Package(
 		.target(name: "SourceLabeler", dependencies: ["Atem"]),
 		.target(name: "MessageDecoder", dependencies: ["Atem"]),
 		.target(name: "DSK", dependencies: ["Atem"]),
+		.target(name: "DSKSource", dependencies: ["Atem"]),
 		.target(name: "USK", dependencies: ["Atem"]),
 		.target(name: "Macro", dependencies: ["Atem"]),
 		.target(name: "ProductName", dependencies: ["Atem"]),

--- a/Sources/Atem/Messages/Actions.swift
+++ b/Sources/Atem/Messages/Actions.swift
@@ -450,3 +450,130 @@ public extension Message.Did {
 	}
 }
 
+// MARK: - Change Downstream Keyer
+
+extension Message.Do {
+	/// Informs a switcher that the downstream keyer on air status should be set
+	public struct ChangeDownstreamKeyerOnAir: SerializableMessage {
+		public static let title = Message.Title(string: "CDsL")
+
+		public let keyer: UInt8
+		public let onAir: Bool
+
+		public init(with bytes: ArraySlice<UInt8>) throws {
+			self.keyer = bytes[relative: 0]
+			self.onAir = bytes[relative: 1] == 1
+		}
+
+		public init(to keyer: UInt8, onAir: Bool) {
+			self.keyer = keyer
+			self.onAir = onAir
+		}
+
+		public var dataBytes: [UInt8] {
+			let onAirInt: UInt8 = onAir == true ? 1 : 0
+			return [keyer, onAirInt , 0, 0]
+		}
+
+		public var debugDescription: String {return "Change DSK \(keyer) On Air to \(onAir)"}
+	}
+}
+extension Message.Did {
+	/// Informs a controller that the downstream keyer on air status has changed
+	public struct ChangeDownstreamKeyerOnAir: SerializableMessage {
+		public static let title = Message.Title(string: "DskS")
+
+		public let keyer: UInt8
+		public let onAir: Bool
+		public let inTransition: Bool
+		public let isAutoTransitioning: Bool
+		public let framesRemaining: UInt8
+
+		public init(with bytes: ArraySlice<UInt8>) throws {
+			keyer = bytes[relative: 0]
+			onAir = bytes[relative: 1] == 1
+			inTransition = bytes[relative: 2] == 1
+			isAutoTransitioning = bytes[relative: 3] == 1
+			framesRemaining = bytes[relative: 4]
+		}
+
+		public init(to keyer: UInt8, onAir: Bool, inTransition: Bool, isAutoTransitioning: Bool, framesRemaining: UInt8 = 0) {
+			self.keyer = keyer
+			self.onAir = onAir
+			self.inTransition = inTransition
+			self.isAutoTransitioning = isAutoTransitioning
+			self.framesRemaining = framesRemaining
+		}
+
+		public var dataBytes: [UInt8] {
+			let onAirInt: UInt8 = onAir ? 1 : 0
+			let inTransitionInt: UInt8 = inTransition ? 1 : 0
+			let isAutoTransitioningInt: UInt8 = isAutoTransitioning ? 1 : 0
+			
+			return [keyer, onAirInt, inTransitionInt, isAutoTransitioningInt, framesRemaining, 0, 0, 0]
+		}
+		public var debugDescription: String {
+			return "DSK \(keyer) changed to On Air \(onAir) inTransition \(inTransition) isAutoTransitioning \(isAutoTransitioning) with \(framesRemaining) frames remaining"
+		}
+	}
+}
+
+// MARK: - Change Upstream Keyer
+
+extension Message.Do {
+	/// Informs a switcher that the downstream keyer on air status should be set
+	public struct ChangeKeyerOnAir: SerializableMessage {
+		public static let title = Message.Title(string: "CKOn")
+
+		public let mixEffect: UInt8
+		public let keyer: UInt8
+		public let enabled: Bool
+
+		public init(with bytes: ArraySlice<UInt8>) throws {
+			self.mixEffect = bytes[relative: 0]
+			self.keyer = bytes[relative: 1]
+			self.enabled = bytes[relative: 2] == 1
+		}
+
+		public init(to mixEffect: UInt8, keyer: UInt8, enabled: Bool) {
+			self.mixEffect = mixEffect
+			self.keyer = keyer
+			self.enabled = enabled
+		}
+
+		public var dataBytes: [UInt8] {
+			let enabledInt: UInt8 = enabled == true ? 1 : 0
+			return [mixEffect, keyer, enabledInt , 0]
+		}
+
+		public var debugDescription: String {return "Change M/E \(mixEffect) USK \(keyer) to \(enabled)"}
+	}
+}
+extension Message.Did {
+	/// Informs a controller that the downstream keyer on air status has changed
+	public struct ChangeKeyerOnAir: SerializableMessage {
+		public static let title = Message.Title(string: "KeOn")
+
+		public let mixEffect: UInt8
+		public let keyer: UInt8
+		public let enabled: Bool
+
+		public init(with bytes: ArraySlice<UInt8>) throws {
+			self.mixEffect = bytes[relative: 0]
+			self.keyer = bytes[relative: 1]
+			self.enabled = bytes[relative: 2] == 1
+		}
+
+		public init(to mixEffect: UInt8, keyer: UInt8, enabled: Bool) {
+			self.mixEffect = mixEffect
+			self.keyer = keyer
+			self.enabled = enabled
+		}
+
+		public var dataBytes: [UInt8] {
+			let enabledInt: UInt8 = enabled == true ? 1 : 0
+			return [mixEffect, keyer, enabledInt , 0]
+		}
+		public var debugDescription: String {return "Change M/E \(mixEffect) USK \(keyer) to \(enabled)"}
+	}
+}

--- a/Sources/Atem/Messages/Actions.swift
+++ b/Sources/Atem/Messages/Actions.swift
@@ -518,6 +518,96 @@ extension Message.Did {
 	}
 }
 
+// MARK: - Downstream Keyer
+
+extension Message.Do {
+	/// Informs a switcher that the downstream keyer fill source should be set
+	public struct ChangeDownstreamKeyerFillSource: SerializableMessage {
+		public static let title = Message.Title(string: "CDsF")
+
+		public let keyer: UInt8
+		public let fillSource: VideoSource
+		
+		public init(with bytes: ArraySlice<UInt8>) throws {
+			self.keyer = bytes[relative: 0]
+			let fillSourceNumber = UInt16(from: bytes[relative: 2..<4])
+			self.fillSource = try VideoSource.decode(from: fillSourceNumber)
+			
+		}
+
+		public init(to keyer: UInt8, fillSource: VideoSource) {
+			self.keyer = keyer
+			self.fillSource = fillSource
+		}
+
+		public var dataBytes: [UInt8] {
+			return [keyer, 0] + fillSource.rawValue.bytes
+		}
+		public var debugDescription: String {
+			return "Set DSK \(keyer) fillSource to: \(fillSource)"
+		}
+	}
+	
+	/// Informs a switcher that the downstream keyer key source should be set
+	public struct ChangeDownstreamKeyerKeySource: SerializableMessage {
+		public static let title = Message.Title(string: "CDsC")
+
+		public let keyer: UInt8
+		public let keySource: VideoSource
+		
+		public init(with bytes: ArraySlice<UInt8>) throws {
+			self.keyer = bytes[relative: 0]
+			let keySourceNumber = UInt16(from: bytes[relative: 2..<4])
+			self.keySource = try VideoSource.decode(from: keySourceNumber)
+		}
+
+		public init(to keyer: UInt8, keySource: VideoSource) {
+			self.keyer = keyer
+			self.keySource = keySource
+		}
+
+		public var dataBytes: [UInt8] {
+			return [keyer, 0] + keySource.rawValue.bytes
+		}
+		public var debugDescription: String {
+			return "Set DSK \(keyer) keySource to: \(keySource)"
+		}
+	}
+}
+
+extension Message.Did {
+	/// informs a controller that the Downstream keyer source and fill has changed
+	public struct ChangeDownstreamKeyer: SerializableMessage {
+		public static let title = Message.Title(string: "DskB")
+
+		public let keyer: UInt8
+		public let fillSource: VideoSource
+		public let keySource: VideoSource
+		
+		public init(with bytes: ArraySlice<UInt8>) throws {
+			self.keyer = bytes[relative: 0]
+			let fillSourceNumber = UInt16(from: bytes[relative: 2..<4])
+			self.fillSource = try VideoSource.decode(from: fillSourceNumber)
+			
+			let keySourceNumber = UInt16(from: bytes[relative: 4..<6])
+			self.keySource = try VideoSource.decode(from: keySourceNumber)
+		}
+
+		public init(to keyer: UInt8, fillSource: VideoSource, keySource: VideoSource) {
+			self.keyer = keyer
+			self.fillSource = fillSource
+			self.keySource = keySource
+		}
+
+		public var dataBytes: [UInt8] {
+			return [keyer, 0] + fillSource.rawValue.bytes + keySource.rawValue.bytes
+		}
+		public var debugDescription: String {
+			return "DSK \(keyer) fillSource: \(fillSource) keySource: \(keySource)"
+		}
+	}
+}
+
 // MARK: - Change Upstream Keyer
 
 extension Message.Do {

--- a/Sources/Atem/Messages/Actions.swift
+++ b/Sources/Atem/Messages/Actions.swift
@@ -487,22 +487,22 @@ extension Message.Did {
 		public let onAir: Bool
 		public let inTransition: Bool
 		public let isAutoTransitioning: Bool
-		public let framesRemaining: UInt8
+		public let remainingFrames: UInt8
 
 		public init(with bytes: ArraySlice<UInt8>) throws {
 			keyer = bytes[relative: 0]
 			onAir = bytes[relative: 1] == 1
 			inTransition = bytes[relative: 2] == 1
 			isAutoTransitioning = bytes[relative: 3] == 1
-			framesRemaining = bytes[relative: 4]
+			remainingFrames = bytes[relative: 4]
 		}
 
-		public init(to keyer: UInt8, onAir: Bool, inTransition: Bool, isAutoTransitioning: Bool, framesRemaining: UInt8 = 0) {
+		public init(to keyer: UInt8, onAir: Bool, inTransition: Bool, isAutoTransitioning: Bool, remainingFrames: UInt8 = 0) {
 			self.keyer = keyer
 			self.onAir = onAir
 			self.inTransition = inTransition
 			self.isAutoTransitioning = isAutoTransitioning
-			self.framesRemaining = framesRemaining
+			self.remainingFrames = remainingFrames
 		}
 
 		public var dataBytes: [UInt8] {
@@ -510,10 +510,10 @@ extension Message.Did {
 			let inTransitionInt: UInt8 = inTransition ? 1 : 0
 			let isAutoTransitioningInt: UInt8 = isAutoTransitioning ? 1 : 0
 			
-			return [keyer, onAirInt, inTransitionInt, isAutoTransitioningInt, framesRemaining, 0, 0, 0]
+			return [keyer, onAirInt, inTransitionInt, isAutoTransitioningInt, remainingFrames, 0, 0, 0]
 		}
 		public var debugDescription: String {
-			return "DSK \(keyer) changed to On Air \(onAir) inTransition \(inTransition) isAutoTransitioning \(isAutoTransitioning) with \(framesRemaining) frames remaining"
+			return "DSK \(keyer) changed to On Air \(onAir) inTransition \(inTransition) isAutoTransitioning \(isAutoTransitioning) with \(remainingFrames) frames remaining"
 		}
 	}
 }
@@ -575,5 +575,46 @@ extension Message.Did {
 			return [mixEffect, keyer, enabledInt , 0]
 		}
 		public var debugDescription: String {return "Change M/E \(mixEffect) USK \(keyer) to \(enabled)"}
+	}
+}
+
+// MARK: - Macro Action
+
+extension Message.Do {
+	/// Informs a switcher that the downstream keyer on air status should be set
+	public struct MacroAction: SerializableMessage {
+		public static let title = Message.Title(string: "MAct")
+
+		public let index: UInt16
+		public let action: UInt8
+
+		enum Action {
+			static let run = 0
+			static let stop = 1
+			static let stopRecording = 2
+			static let insertWait = 3
+			static let continueMacro = 4
+			static let delete = 5
+		}
+		
+		public init(with bytes: ArraySlice<UInt8>) throws {
+			self.index = UInt16(from: bytes[relative: 0..<2])
+			self.action = bytes[relative: 2]
+		}
+
+		public init(index: UInt16, action: UInt8) {
+			self.index = index
+			self.action = action
+		}
+
+		public var dataBytes: [UInt8] {
+			let indexArray = index.bytes
+			
+			return indexArray + [action, 0]
+		}
+
+		public var debugDescription: String {
+			return "Macro: \(index) action: \(action)"
+		}
 	}
 }

--- a/Sources/DSK/main.swift
+++ b/Sources/DSK/main.swift
@@ -1,0 +1,44 @@
+//
+//  main.swift
+//  
+//
+//  Created by adamtow on 12/01/2021.
+//
+
+import Foundation
+import Atem
+
+let address: String
+if CommandLine.arguments.count > 1 {
+	address = CommandLine.arguments[1]
+} else {
+	print("Enter switcher IP address: ", terminator: "")
+	address = readLine() ?? "10.1.0.210"
+}
+print("Trying to connect to switcher with IP addres", address)
+
+let controller = try Controller(ipAddress: address) { connection in
+	connection.when{ (change: Did.ChangeDownstreamKeyerOnAir) in
+		print(change) // prints: 'Preview bus changed to input(x)'
+	}
+
+	connection.when { (connected: Config.InitiationComplete) in
+		print(connected)
+		print("Type 1 or 0 and <enter> to change the On Air status of the DSK 0")
+	}
+
+	connection.whenDisconnected = {
+		print("Disconnected")
+	}
+}
+
+var sourceString: String
+while true {
+	sourceString = readLine() ?? "1"
+	guard let sourceNumber = UInt16(sourceString) else {
+		print("invalid source")
+		continue
+	}
+	
+	controller.send(message: Do.ChangeDownstreamKeyerOnAir(to: 0, onAir: sourceNumber == 1))
+}

--- a/Sources/DSKSource/main.swift
+++ b/Sources/DSKSource/main.swift
@@ -21,10 +21,14 @@ let controller = try Controller(ipAddress: address) { connection in
 	connection.when{ (change: Did.ChangeDownstreamKeyerOnAir) in
 		print(change) // prints: 'Preview bus changed to input(x)'
 	}
+	
+	connection.when{ (change: Did.ChangeDownstreamKeyer) in
+		print(change) // prints: 'Preview bus changed to input(x)'
+	}
 
 	connection.when { (connected: Config.InitiationComplete) in
 		print(connected)
-		print("Type 1 or 0 and <enter> to change the On Air status of the DSK 1")
+		print("Type a source <enter> to change the fill source of the DSK 1")
 	}
 
 	connection.whenDisconnected = {
@@ -40,5 +44,7 @@ while true {
 		continue
 	}
 	
-	controller.send(message: Do.ChangeDownstreamKeyerOnAir(to: 0, onAir: sourceNumber == 1))
+	let fillSource = VideoSource(rawValue: sourceNumber)
+
+	controller.send(message: Do.ChangeDownstreamKeyerFillSource(to: 0, fillSource: fillSource))
 }

--- a/Sources/Macro/main.swift
+++ b/Sources/Macro/main.swift
@@ -1,0 +1,48 @@
+//
+//  main.swift
+//  
+//
+//  Created by adamtow on 12/01/2021.
+//
+
+import Foundation
+import Atem
+
+let address: String
+if CommandLine.arguments.count > 1 {
+	address = CommandLine.arguments[1]
+} else {
+	print("Enter switcher IP address: ", terminator: "")
+	address = readLine() ?? "10.1.0.210"
+}
+print("Trying to connect to switcher with IP addres", address)
+
+let controller = try Controller(ipAddress: address) { connection in
+	connection.when{ (change: Config.MacroPool) in
+		print(change) // prints: 'Number of macro pool banks: input(x)'
+	}
+
+	connection.when { (change: Config.MacroProperties) in
+		print(change) // prints: list of macros
+	}
+	
+	connection.when { (connected: Config.InitiationComplete) in
+		print(connected)
+		print("Type a number to run the macro at that index")
+	}
+
+	connection.whenDisconnected = {
+		print("Disconnected")
+	}
+}
+
+var macroIndexString: String
+while true {
+	macroIndexString = readLine() ?? "1"
+	guard let macroIndex = UInt8(macroIndexString) else {
+		print("invalid macroIndex")
+		continue
+	}
+	
+	controller.send(message: Do.MacroAction(index: UInt16(macroIndex), action: 0))
+}

--- a/Sources/ProductName/main.swift
+++ b/Sources/ProductName/main.swift
@@ -1,0 +1,37 @@
+//
+//  main.swift
+//  
+//
+//  Created by adamtow on 12/01/2021.
+//
+
+import Foundation
+import Atem
+
+let address: String
+if CommandLine.arguments.count > 1 {
+	address = CommandLine.arguments[1]
+} else {
+	print("Enter switcher IP address: ", terminator: "")
+	address = readLine() ?? "10.1.0.210"
+}
+print("Trying to connect to switcher with IP addres", address)
+
+let controller = try Controller(ipAddress: address) { connection in
+	connection.when{ (change: Config.ProductName) in
+		print(change)
+	}
+
+	connection.when { (connected: Config.InitiationComplete) in
+		print(connected)
+	}
+
+	connection.whenDisconnected = {
+		print("Disconnected")
+	}
+}
+
+var sourceString: String
+while true {
+	
+}

--- a/Sources/USK/main.swift
+++ b/Sources/USK/main.swift
@@ -24,7 +24,7 @@ let controller = try Controller(ipAddress: address) { connection in
 
 	connection.when { (connected: Config.InitiationComplete) in
 		print(connected)
-		print("Type 1 or 0 and <enter> to change the Enabled status of the USK 0 on M/E 0")
+		print("Type 1 or 0 and <enter> to change the Enabled status of the USK 1 on M/E 0")
 	}
 
 	connection.whenDisconnected = {

--- a/Sources/USK/main.swift
+++ b/Sources/USK/main.swift
@@ -1,0 +1,44 @@
+//
+//  main.swift
+//  
+//
+//  Created by adamtow on 12/01/2021.
+//
+
+import Foundation
+import Atem
+
+let address: String
+if CommandLine.arguments.count > 1 {
+	address = CommandLine.arguments[1]
+} else {
+	print("Enter switcher IP address: ", terminator: "")
+	address = readLine() ?? "10.1.0.210"
+}
+print("Trying to connect to switcher with IP addres", address)
+
+let controller = try Controller(ipAddress: address) { connection in
+	connection.when{ (change: Did.ChangeKeyerOnAir) in
+		print(change) // prints: 'Preview bus changed to input(x)'
+	}
+
+	connection.when { (connected: Config.InitiationComplete) in
+		print(connected)
+		print("Type 1 or 0 and <enter> to change the Enabled status of the USK 0 on M/E 0")
+	}
+
+	connection.whenDisconnected = {
+		print("Disconnected")
+	}
+}
+
+var sourceString: String
+while true {
+	sourceString = readLine() ?? "1"
+	guard let sourceNumber = UInt16(sourceString) else {
+		print("invalid source")
+		continue
+	}
+	
+	controller.send(message: Do.ChangeKeyerOnAir(to: 0, keyer: 0, enabled: sourceNumber == 1))
+}


### PR DESCRIPTION
Added the following commands:  KeOn, CKOn, CDsL, DskS, CDsF, CDsC, DskB, MAct, MPrp, _MAC, and _pin (revised with new message) to support turning on/off the USK and DSK, setting the fill/key source for the DSK, listing macros, and running macros.